### PR TITLE
Expose cassandra connection creation to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ datastores = [
 Runner.setup(datastores: datastores, schema_base_path: 'my/base/path')
 ```
 
+This allows CassSchema to be integrated into other configuration schemes more easily.
+
+Additionally, the global `CassSchema::Runner` object need not be used: An instance of `CassSchema::Runner` can be
+constructed and used in the same manner as the global object:
+
+```ruby
+# Accepts the same arguments as Runner#setup
+runner = Runner.new(datastores: datastores, schema_base_path: 'my/base/path')
+runner.create_all
+```
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Or install it yourself as:
 Before usage, CassSchema must be initialized with a set of datastore objects, as well as a base directory where the schema definitions live:
 
 ```ruby
-CassSchema::Runner.datastores = CassSchema::YamlHelper.datastores('my/path/to/config.yml')
-CassSchema::Runner.schema_base_path = 'my/path/to/schema/root'
+CassSchema::Runner.initialize(
+  datastores: CassSchema::YamlHelper.datastores('my/path/to/config.yml'),
+  schema_base_path: 'my/path/to/schema/root')
 ```
 
 Here the datastores are a list of `CassSchema::DataStore` objects. These may be build manually, or loaded from a yaml file using the `CassSchema::YamlHelper`. CassSchema is intentionally agnostic about the source of these datastores.
@@ -89,6 +90,22 @@ CassSchema::Runner.migrate('datastore', 'migration')
 ```
 
 Here the migration file 'migration.cql' should exist.
+
+### Integration with other libraries
+
+While `CassSchema::YamlLoader` provides ease of use, it is not required: the runner can be instantiated
+with any list of `CassSchema::Datastore` objects. Here is an example manual set up:
+
+```ruby
+cluster = CassSchema::Cluster.build(hosts: ['127.0.0.1'], port: 9242)
+replication = "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+datastores = [
+  CassSchema::Datastore.build('test_datastore', cluster: cluster, keyspace: 'test_keyspace', replication: replication),
+  CassSchema::Datastore.build('test_datastore2', cluster: cluster, keyspace: 'test_keyspace2', replication: replication),
+]
+Runner.setup(datastores: datastores, schema_base_path: 'my/base/path')
+```
+
 
 ## Contributing
 

--- a/lib/cass_schema/cluster.rb
+++ b/lib/cass_schema/cluster.rb
@@ -8,7 +8,7 @@ module CassSchema
       l = hash.with_indifferent_access
 
       if l[:hosts]
-        l[:connection] ||= Cassandra.cluster(:hosts => l[:hosts], :port => l[:port])
+        l[:connection] ||= Cassandra.cluster(hosts: l[:hosts], port: l[:port])
       end
 
       new(l[:connection])

--- a/lib/cass_schema/cluster.rb
+++ b/lib/cass_schema/cluster.rb
@@ -1,11 +1,16 @@
+require 'cassandra'
+
 module CassSchema
   # A struct representing a Cassandra cluster.
   # @param [Array<String>] A list of hosts defining the cluster
   # @param [Integer] the port to use for the cluster
-  Cluster = Struct.new(:hosts, :port) do
+  # @param [Cassandra::Cluster] connection to the cassandra cluster to be used.
+  Cluster = Struct.new(:hosts, :port, :connection) do
     def self.build(hash)
       l = hash.with_indifferent_access
-      new(l[:hosts], l[:port])
+      l[:connection] ||= Cassandra.cluster(:hosts => l[:hosts], :port => l[:port])
+
+      new(l[:hosts], l[:port], l[:connection])
     end
   end if !defined?(Cluster)
 end

--- a/lib/cass_schema/cluster.rb
+++ b/lib/cass_schema/cluster.rb
@@ -2,15 +2,16 @@ require 'cassandra'
 
 module CassSchema
   # A struct representing a Cassandra cluster.
-  # @param [Array<String>] A list of hosts defining the cluster
-  # @param [Integer] the port to use for the cluster
   # @param [Cassandra::Cluster] connection to the cassandra cluster to be used.
-  Cluster = Struct.new(:hosts, :port, :connection) do
+  Cluster = Struct.new(:connection) do
     def self.build(hash)
       l = hash.with_indifferent_access
-      l[:connection] ||= Cassandra.cluster(:hosts => l[:hosts], :port => l[:port])
 
-      new(l[:hosts], l[:port], l[:connection])
+      if l[:hosts]
+        l[:connection] ||= Cassandra.cluster(:hosts => l[:hosts], :port => l[:port])
+      end
+
+      new(l[:connection])
     end
   end if !defined?(Cluster)
 end

--- a/lib/cass_schema/cluster.rb
+++ b/lib/cass_schema/cluster.rb
@@ -1,0 +1,11 @@
+module CassSchema
+  # A struct representing a Cassandra cluster.
+  # @param [Array<String>] A list of hosts defining the cluster
+  # @param [Integer] the port to use for the cluster
+  Cluster = Struct.new(:hosts, :port) do
+    def self.build(hash)
+      l = hash.with_indifferent_access
+      new(l[:hosts], l[:port])
+    end
+  end if !defined?(Cluster)
+end

--- a/lib/cass_schema/datastore.rb
+++ b/lib/cass_schema/datastore.rb
@@ -1,19 +1,10 @@
-require_relative 'runner'
 require_relative 'errors'
+require_relative 'statement_loader'
+require_relative 'cluster'
 require 'active_support/core_ext/hash'
 require 'active_support/core_ext/object'
 
 module CassSchema
-  # A struct representing a Cassandra cluster.
-  # @param [Array<String>] A list of hosts defining the cluster
-  # @param [Integer] the port to use for the cluster
-  Cluster = Struct.new(:hosts, :port) do
-    def self.build(hash)
-      l = hash.with_indifferent_access
-      new(l[:hosts], l[:port])
-    end
-  end if !defined?(Cluster)
-
   # A struct representing a datastore, composed of the following fields:
   # @param [String] name of the datastore
   # @param [CassSchema::Cluster] A list of hosts and a port representing the cluster.
@@ -25,6 +16,8 @@ module CassSchema
   # comments start with '#'
   DataStore = Struct.new(:name, :cluster, :keyspace, :replication, :schema) do
 
+    attr_reader :schema_base_path, :logger
+
     # Creates a datastore object from a hash containing the required keys
     # @param [String] name of the data store
     # @option [CassSchema::Cluster] :cluster
@@ -35,6 +28,12 @@ module CassSchema
       l = hash.with_indifferent_access
       schema = l[:schema] || name
       new(name, l[:cluster], l[:keyspace], l[:replication], schema)
+    end
+
+    # Populates the Datastore with state from the Runner.
+    def setup(options = {})
+      @schema_base_path = options[:schema_base_path]
+      @logger = options[:logger]
     end
 
     def create
@@ -77,11 +76,11 @@ module CassSchema
     end
 
     def create_statements
-      StatementLoader.statements(schema, 'schema.cql')
+      StatementLoader.statements(schema_base_path, schema, 'schema.cql')
     end
 
     def migration_statements(migration_name)
-      StatementLoader.statements(schema, 'migrations', "#{migration_name}.cql")
+      StatementLoader.statements(schema_base_path, schema, 'migrations', "#{migration_name}.cql")
     end
 
     def create_keyspace
@@ -93,34 +92,7 @@ module CassSchema
     end
 
     def log(msg, level = :info)
-      Runner.logger.try { |l| l.send(level, msg) }
+      logger.try { |l| l.send(level, msg) }
     end
   end if !defined?(DataStore)
-
-  class StatementLoader
-    class << self
-      def path_for_schema(schema)
-        File.join(Runner.schema_base_path, schema)
-      end
-
-      def statements(schema, *path_parts)
-        file_path = File.join(path_for_schema(schema), path_parts)
-        file = File.open(file_path).read
-
-        # Parse the individual CQL statements as a list from the file. To do so:
-        # - assume statements are separated by two new lines
-        # - strip comments and empty lines from each statement
-        # - remove statements that are empty
-        statements = file.split(/\n{2,}/).map do |statement|
-          statement
-            .split(/\n/)
-            .select { |l| l !~ /^\s*#/ }
-            .select { |l| l !~ /^\s*$/ }
-            .join("\n")
-        end
-
-        statements.select { |s| s.length > 0 }
-      end
-    end
-  end
 end

--- a/lib/cass_schema/datastore.rb
+++ b/lib/cass_schema/datastore.rb
@@ -52,17 +52,11 @@ module CassSchema
     private
 
     def client
-      @client ||= begin
-                    cl = Cassandra.cluster(:hosts => cluster.hosts, :port => cluster.port)
-                    cl.connect(keyspace)
-                  end
+      @client ||= cluster.connection.connect(keyspace)
     end
 
     def general_client
-      @general_client ||= begin
-                            cl = Cassandra.cluster(:hosts => cluster.hosts, :port => cluster.port)
-                            cl.connect
-                          end
+      @general_client ||= cluster.connection.connect
     end
 
     def run_statement(statement, client)

--- a/lib/cass_schema/statement_loader.rb
+++ b/lib/cass_schema/statement_loader.rb
@@ -1,0 +1,24 @@
+module CassSchema
+  class StatementLoader
+    class << self
+      def statements(*path_parts)
+        file_path = File.join(path_parts)
+        file = File.open(file_path).read
+
+        # Parse the individual CQL statements as a list from the file. To do so:
+        # - assume statements are separated by two new lines
+        # - strip comments and empty lines from each statement
+        # - remove statements that are empty
+        statements = file.split(/\n{2,}/).map do |statement|
+          statement
+            .split(/\n/)
+            .select { |l| l !~ /^\s*#/ }
+            .select { |l| l !~ /^\s*$/ }
+            .join("\n")
+        end
+
+        statements.select { |s| s.length > 0 }
+      end
+    end
+  end
+end

--- a/test/cass_schema/runner_test.rb
+++ b/test/cass_schema/runner_test.rb
@@ -4,9 +4,9 @@ module CassSchema
   class RunnerTest < MiniTest::Should::TestCase
 
     setup do
-      base_path = "#{File.dirname(__FILE__)}/../fixtures"
-      Runner.setup(:datastores => YamlHelper.datastores(File.join(base_path, 'test_config.yml')),
-                   :schema_base_path => base_path)
+      @base_path = "#{File.dirname(__FILE__)}/../fixtures"
+      Runner.setup(:datastores => YamlHelper.datastores(File.join(@base_path, 'test_config.yml')),
+                   :schema_base_path => @base_path)
     end
 
     teardown do
@@ -79,6 +79,34 @@ module CassSchema
 
       should 'raise an error if a datastore does not exist' do
         assert_raises(ArgumentError) { Runner.create('nonexistent_datastore') }
+      end
+    end
+
+    context 'custom setup' do
+      setup do
+        connection = Cassandra.cluster(hosts: %w(127.0.0.1), port: 9242)
+        cluster = Cluster.build(connection: connection)
+        datastores = [DataStore.build('test_datastore',
+                                      cluster: cluster,
+                                      keyspace: 'test_keyspace',
+                                      replication: "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }")]
+        @runner = Runner.new(datastores: datastores, schema_base_path: @base_path )
+      end
+
+      should 'be able to create a datastore' do
+        @runner.create('test_datastore')
+        tables = tables_for_keyspace('test_keyspace')
+        assert_equal %w(test test2).to_set, tables.map { |t| t['columnfamily_name'] }.to_set
+      end
+
+      should 'be able to run a migration' do
+        @runner.create('test_datastore')
+        @runner.migrate('test_datastore', 'migration')
+        schema = schema_for_table('test_datastore', 'test')
+
+        column = schema.find { |col| col['column_name'] == 'new_column'}
+        assert column
+        assert_equal 'org.apache.cassandra.db.marshal.Int32Type', column['validator']
       end
     end
   end

--- a/test/cass_schema/runner_test.rb
+++ b/test/cass_schema/runner_test.rb
@@ -5,8 +5,8 @@ module CassSchema
 
     setup do
       @base_path = "#{File.dirname(__FILE__)}/../fixtures"
-      Runner.setup(:datastores => YamlHelper.datastores(File.join(@base_path, 'test_config.yml')),
-                   :schema_base_path => @base_path)
+      Runner.setup(datastores: YamlHelper.datastores(File.join(@base_path, 'test_config.yml')),
+                   schema_base_path: @base_path)
     end
 
     teardown do

--- a/test/cass_schema/runner_test.rb
+++ b/test/cass_schema/runner_test.rb
@@ -5,8 +5,8 @@ module CassSchema
 
     setup do
       base_path = "#{File.dirname(__FILE__)}/../fixtures"
-      Runner.datastores = YamlHelper.datastores(File.join(base_path, 'test_config.yml'))
-      Runner.schema_base_path = base_path
+      Runner.setup(:datastores => YamlHelper.datastores(File.join(base_path, 'test_config.yml')),
+                   :schema_base_path => base_path)
     end
 
     teardown do


### PR DESCRIPTION
This cleans up the implementation, making `Runner` function as a class that can be instantiated instead of a global object. A `:connection` parameter can now be passed into `Cluster` so that the cluster will use the provided connection. This allows clusters with more complicated instantiation (beyond just host and port) to be used.
