### PR TITLE
Add Optional Safe Mode

### DIFF
--- a/lib/cass_schema/runner.rb
+++ b/lib/cass_schema/runner.rb
@@ -1,6 +1,13 @@
 module CassSchema
   class Runner
-    attr_reader :datastores, :schema_base_path, :logger, :cluster_builder
+
+    class DropCommandsNotAllowed < StandardError
+      def initialize(*_)
+        super('Drop commands have been disabled by the :disallow_drops option')
+      end
+    end
+
+    attr_reader :datastores, :schema_base_path, :logger, :cluster_builder, :disallow_drops
 
     # Create a new Runner
     # @option options [Array<CassSchema::Datastore>] :datastores - The list of datastore objects for which schemas
@@ -8,12 +15,15 @@ module CassSchema
     # @option options [String] :schema_bath_path - The directory where schema definitions live. In a rails env,
     #   this defaults to <rails root>/cass_schema.
     # @option options [#info|#error] :logger optional logger to use when creating schemas
+    # @option options [Boolean] :disallow_drops Defaults to false. If set to true,
+    # drop commands will raise an exception instead of executing the command.
     def initialize(options = {})
       options[:schema_base_path] ||= defined?(::Rails) ? File.join(::Rails.root, 'cass_schema') : nil
 
       @datastores = options[:datastores]
       @schema_base_path = options[:schema_base_path]
       @logger = options[:logger]
+      @disallow_drops = options[:disallow_drops]
 
       raise ":datastores is a required argument!" unless @datastores
 
@@ -27,6 +37,7 @@ module CassSchema
 
     # Drop all schemas for all datastores
     def drop_all
+      raise DropCommandsNotAllowed if disallow_drops
       datastores.each { |d| d.drop }
     end
 
@@ -39,6 +50,7 @@ module CassSchema
     # Drop the schema for a particular datastore
     # @param [String] datastore_name
     def drop(datastore_name)
+      raise DropCommandsNotAllowed if disallow_drops
       datastore_lookup(datastore_name).drop
     end
 


### PR DESCRIPTION
In production environments, the drop commands may be somewhat dangerous,
and so it may be desirable to disable them. This adds a parameter that
does so.
