### PR TITLE
add option to specify full schema base path

### DIFF
--- a/test/cass_schema/datastore_test.rb
+++ b/test/cass_schema/datastore_test.rb
@@ -1,0 +1,13 @@
+require_relative '../test_helper'
+
+module CassSchema
+  class DataStoreTest < MiniTest::Should::TestCase
+    context '#build' do
+      should 'accept the schema base path as an option' do
+        schema_base_path = File.expand_path(__FILE__, '../')
+        ds = CassSchema::DataStore.build("hello", schema_base_path: schema_base_path)
+        assert_equal File.join(schema_base_path, 'hello', 'schema.cql'), ds.schema_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses #6 

Not the smoothest, but it works. Example usage:

``` rb
gem_path = Bundler.load.specs.find { |s| s.name == 'my_gem' }.full_gem_path
CassSchema::DataStore.build('my_schema', schema_base_path: gem_path)
```
